### PR TITLE
Fix property name for `max_line_length` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
 * end_of_line
 * charset
 * trim_trailing_whitespace
-* max_line_width
+* max_line_length
 * root (only used by EditorConfig core)
 
 ## Bugs and Feature Requests


### PR DESCRIPTION
According to [editorconfig wiki](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length) and [plugin code](https://github.com/editorconfig/editorconfig-vim/blob/master/plugin/editorconfig.vim#L543), `max_line_length` is the correct propery name, not `max_line_width`.
