### PR TITLE
Add autoload copying to installation instructions

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -54,7 +54,7 @@ Download the [EditorConfig core][] and follow the instructions in the README
 and INSTALL files to install it.
 
 Once EditorConfig core is installed, copy the `plugin/editorconfig.vim` file
-to your `~/.vim/plugin` directory and `doc/editorconfig.txt` to your
+to your `~/.vim/plugin` directory, `autoload/editorconfig.vim` to `~/.vim/autoload`  and `doc/editorconfig.txt` to your
 `~/.vim/doc` directory to install the EditorConfig plugin.
 
 COMMANDS~


### PR DESCRIPTION
If you don't copy this file you might get an error such as:

Error detected while processing function <SNR>7_UseConfigFiles..<SNR>7_UseConfig
Files_ExternalCommand..<SNR>7_SpawnExternalParser..<SNR>7_ApplyConfig:
line   96:
E117: Unknown function: editorconfig#ApplyHooks

(see this issue https://github.com/editorconfig/editorconfig/issues/66)
