### PR TITLE
Fix Vim help being treated as text files

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -475,6 +475,11 @@ function! s:SpawnExternalParser(cmd) " {{{2
 endfunction
 
 function! s:ApplyConfig(config) " {{{1
+    " Only process normal buffers (do not treat help files as '.txt' files)
+    if !empty(&buftype)
+        return
+    endif
+
 " Set the indentation style according to the config values
 
     if has_key(a:config, "indent_style")


### PR DESCRIPTION
Vim help authors rely on modelines to achieve consistent formatting; unluckily, editorconfig doesn’t know anything about them, and treats english Vim help files as bog standard _*.txt_ files even when displayed by the `:h` command, i.e. being non-editable and needing consistent presentation. This results in help being displayed like this:

![netrw help pre-pr](https://cloud.githubusercontent.com/assets/80906/4768324/8030cf26-5b68-11e4-9b7f-3699d3046f01.png)

when it should be displayed like this (notice the difference in header alignment):

![netrw help post-pr](https://cloud.githubusercontent.com/assets/80906/4768332/879e1dae-5b68-11e4-8c45-c10072339de5.png)

Short of being able to defer to modelines (which Vim has no API for whatsoever, and which would open up thorny questions of priority anyway), this PR solves the issue for help files being displayed by `:h` by bailing out of editorconfig settings application on a non-file buffers, of which _help_ displays are one.

Note this leaves the issue of having incompatible expectations when **editing** these files open, but that would be a far less common use case and one where we can reasonably expect plugin devs to add a documentation specific _.editorconfig_ file.
