### PR TITLE
Reload config on file name changes

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -352,10 +352,9 @@ endfunction
 " command, autoload {{{1
 command! EditorConfigReload call s:UseConfigFiles() " Reload EditorConfig files
 augroup editorconfig
-autocmd! editorconfig
-autocmd editorconfig BufNewFile,BufReadPost * call s:UseConfigFiles()
-autocmd editorconfig BufNewFile,BufRead .editorconfig set filetype=dosini
-
+    autocmd!
+    autocmd BufNewFile,BufReadPost,BufFilePost * call s:UseConfigFiles()
+    autocmd BufNewFile,BufRead .editorconfig set filetype=dosini
 augroup END
 
 " UseConfigFiles function for different mode {{{1


### PR DESCRIPTION
As EditorConfig is wholly filename pattern based and has path dependent configuration, it makes sense to reload the config automatically when the file name and / or path changes, instead of letting the user figure out they need to issue an `:EditorConfigReload` command. For added awesomeness, this makes the plugin smarter than most Vim filetype plugins, which take their cue from Vim’s `:h filetype.txt` and rarely (if at all) watch rename operations.

The PR also cleans up the autocommand group code by removing the redundant group name arguments (these are not needed inside an `augroup name ... augroup END` block – see `:h augroup`). 
