### PR TITLE
Use https for submodules instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/spec/plugin_tests"]
 	path = tests/spec/plugin_tests
-	url = git://github.com/editorconfig/editorconfig-plugin-tests.git
+	url = https://github.com/editorconfig/editorconfig-plugin-tests.git


### PR DESCRIPTION
Https should be faster and also will help with people stuck behind certain firewalls/proxies.
