### PR TITLE
Uses a range(&textwidth,&columns) instead of a single column on vim.

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -557,9 +557,9 @@ function! s:ApplyConfig(config) " {{{1
         if l:max_line_length > 0
             let &l:textwidth = l:max_line_length
 
-            " highlight the column
+            " highlight the columns following max_line_length
             if exists('+colorcolumn')
-                let &l:colorcolumn = join(range(l:max_line_length,&l:columns),',')
+                let &l:colorcolumn = join(range(l:max_line_length+1,&l:columns),',')
             endif
         endif
     endif

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -559,7 +559,7 @@ function! s:ApplyConfig(config) " {{{1
 
             " highlight the column
             if exists('+colorcolumn')
-                let &l:colorcolumn = l:max_line_length
+                let &l:colorcolumn = join(range(l:max_line_length,&l:columns),',')
             endif
         endif
     endif


### PR DESCRIPTION
It is much more elegant than a single column being highlighted.