### PR TITLE
Described how to verify if python is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two ways for installation:
   the most simple way to install this plugin is to 
   download the archive and extract it into your Vim runtime directory (`~/.vim`
   on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows).
-  You can verify if `+python` is supported by running `:ver`.
+  You can verify if the `+python` feature is included by running `:ver`.
 
 - If your Vim is not compiled with `+python` feature, please first download the
   [EditorConfig core][] and follow the instructions in the README and INSTALL

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ This is an [EditorConfig][] plugin for Vim. This plugin could be found on both
 There are two ways for installation:
 
 - If your Vim is compiled with `+python` feature (this is usually true on most
-  Linux distributions), the most simple way to install this plugin is to
+  Linux distributions and with the main Windows binary installers), 
+  the most simple way to install this plugin is to 
   download the archive and extract it into your Vim runtime directory (`~/.vim`
-  on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows).
+  on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows). 
+  You can verify if `+python` is supported by running `:py print 2+2`.
 
 - If your Vim is not compiled with `+python` feature, please first download the
   [EditorConfig core][] and follow the instructions in the README and INSTALL

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ There are two ways for installation:
   Linux distributions and with the main Windows binary installers), 
   the most simple way to install this plugin is to 
   download the archive and extract it into your Vim runtime directory (`~/.vim`
-  on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows). 
-  You can verify if `+python` is supported by running `:py print 2+2`.
+  on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows).
+  You can verify if `+python` is supported by running `:ver`.
 
 - If your Vim is not compiled with `+python` feature, please first download the
   [EditorConfig core][] and follow the instructions in the README and INSTALL


### PR DESCRIPTION
I was not aware that my vanilla Windows installation has python enabled, and took bit to long to find out that I could use the simple installation alternative.
From http://vim.wikia.com/wiki/Build_Python-enabled_Vim_on_Windows_with_MinGW states
>You may not need this tip because the two main Windows installers for Vim usually already have Python support