### PR TITLE
Forced formatoptions to have at least 'tc'

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -170,6 +170,15 @@ path relative to any of the directories in 'runtimepath'. The default value is
 "plugin/editorconfig-core-py", which means all "plugin/editorconfig-core-py"
 directory in 'runtimepath' will be searched.
 
+                                            *g:EditorConfig_preserve_formatoptions*
+Set this to 1 if you don't want your formatoptions modified when
+max_line_length is set:
+>
+ let g:EditorConfig_preserve_formatoptions = 1
+<
+
+This option defaults to 0.
+
                                             *g:EditorConfig_verbose*
 Set this to 1 if you want debug info printed:
 >

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -49,6 +49,10 @@ if !exists('g:EditorConfig_verbose')
     let g:EditorConfig_verbose = 0
 endif
 
+if !exists('g:EditorConfig_preserve_formatoptions')
+    let g:EditorConfig_preserve_formatoptions = 0
+endif
+
 if !exists('g:EditorConfig_max_line_indicator')
     let g:EditorConfig_max_line_indicator = 'line'
 endif
@@ -579,6 +583,9 @@ function! s:ApplyConfig(config) " {{{1
 
         if l:max_line_length >= 0
             let &l:textwidth = l:max_line_length
+            if g:EditorConfig_preserve_formatoptions == 0
+                setlocal formatoptions+=tc
+            endif
         endif
 
         if exists('+colorcolumn')


### PR DESCRIPTION
I also added a g:EditorConfig_preserve_formatoptions to keep the old behavior, if anyone wanted that.

Let me know if I'm making any mistakes, this is my first time doing anything serious with vimscript.
Thanks!