### PR TITLE
Fix a syntax error in Python 3

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -402,7 +402,7 @@ ec_data['conf_file'] = ".editorconfig"
 
 try:
     ec_data['options'] = editorconfig.get_properties(ec_data['filename'])
-except editorconfig_except.EditorConfigError, e:
+except editorconfig_except.EditorConfigError as e:
     if int(vim.eval('g:EditorConfig_verbose')) != 0:
         print >> sys.stderr, str(e)
     vim.command('let l:ret = 1')


### PR DESCRIPTION
As it says on the tin. The syntax for catching exceptions changed in Python 3. The new syntax is compatible with Python 2.6, 2.7, and all 3.x versions.