### PR TITLE
Fix missing error variable

### DIFF
--- a/plugin/editorconfig-core-py/editorconfig/main.py
+++ b/plugin/editorconfig-core-py/editorconfig/main.py
@@ -69,7 +69,7 @@ def main():
         handler = EditorConfigHandler(filename, conf_filename, version_tuple)
         try:
             options = handler.get_configurations()
-        except (ParsingError, PathError, VersionError):
+        except (ParsingError, PathError, VersionError) as e:
             print(str(e))
             sys.exit(2)
         if multiple_files:


### PR DESCRIPTION
The error was not assigned to a variable, which caused a NameError to be thrown in the error handling branch.