### PR TITLE
Support insert_final_newline by fixendofline option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
 * `tab_width`
 * `end_of_line`
 * `charset`
-* `insert_final_newline` ([PreserveNoEOL][] is required for this property)
+* `insert_final_newline` (Vim 7.4.785 or later or [PreserveNoEOL][] is required for this property)
 * `trim_trailing_whitespace`
 * `max_line_length`
 * `root` (only used by EditorConfig core)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
 * `tab_width`
 * `end_of_line`
 * `charset`
-* `insert_final_newline` (Vim 7.4.785 or later or [PreserveNoEOL][] is required for this property)
+* `insert_final_newline` (Feature +fixendofline is enabled which is available on Vim 7.4.785+, or [PreserveNoEOL][] is required for this property)
 * `trim_trailing_whitespace`
 * `max_line_length`
 * `root` (only used by EditorConfig core)

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -572,8 +572,16 @@ function! s:ApplyConfig(config) " {{{1
     augroup END
 
     if has_key(a:config, "insert_final_newline")
-        if a:config["insert_final_newline"] == "false"
-            silent! SetNoEOL    " Use the PreserveNoEOL plugin to accomplish it
+        if exists('+fixendofline')
+            if a:config["insert_final_newline"] == "false"
+                setl nofixendofline
+            else
+                setl fixendofline
+            endif
+        elseif  exists(':SetNoEOL') == 2
+            if a:config["insert_final_newline"] == "false"
+                silent! SetNoEOL    " Use the PreserveNoEOL plugin to accomplish it
+            endif
         endif
     endif
 

--- a/tests/spec/editorconfig_spec.rb
+++ b/tests/spec/editorconfig_spec.rb
@@ -106,5 +106,16 @@ describe 'plugin/editorconfig.vim' do
       fileencoding: 'latin1'
   end
 
-  # insert_final_newline tests are omitted, since they are not supported
+  # insert_final_newline by PreserveNoEOL tests are omitted, since they are not supported
+  if $vim.echo("exists('+fixendofline')") == '1'
+    it 'with_newline.txt' do
+      test_editorconfig 'with_newline.txt',
+        fixendofline: '1'
+    end
+
+    it 'without_newline.txt' do
+      test_editorconfig 'without_newline.txt',
+        fixendofline: '0'
+    end
+  end
 end


### PR DESCRIPTION
`fixendofline` option is available on Vim 7.4.785 or later.
https://github.com/vim/vim/commit/de9d99856291ff191e7807f3a56e608c3615f9d4

If use this option, `insert_final_newline` is implemented by pure vim only.