### PR TITLE
Support python3

### DIFF
--- a/plugin/editorconfig.py
+++ b/plugin/editorconfig.py
@@ -11,12 +11,11 @@ try:
 
         import editorconfig
         import editorconfig.exceptions as editorconfig_except
-
     except:
         vim.command('let l:ret = 3')
         raise
-
-    del sys.path[0]
+    finally:
+        del sys.path[0]
 
     # `ec_` prefix is used in order to keep clean Python namespace
     ec_data = {}

--- a/plugin/editorconfig.py
+++ b/plugin/editorconfig.py
@@ -31,13 +31,12 @@ try:
         except editorconfig_except.EditorConfigError as e:
             if int(vim.eval('g:EditorConfig_verbose')) != 0:
                 print(str(e), file=sys.stderr)
-            return 1
+            vim.command('let l:ret = 1')
+            return
 
         for key, value in ec_data['options'].items():
             vim.command("let l:config['" + key.replace("'", "''") + "'] = " +
                 "'" + value.replace("'", "''") + "'")
-
-        return 0
 
 except:
     pass

--- a/plugin/editorconfig.py
+++ b/plugin/editorconfig.py
@@ -1,0 +1,42 @@
+try:
+    try:
+        import vim
+        import sys
+    except:
+        vim.command('let l:ret = 2')
+        raise
+
+    try:
+        sys.path.insert(0, vim.eval('a:editorconfig_core_py_dir'))
+
+        import editorconfig
+        import editorconfig.exceptions as editorconfig_except
+
+    except:
+        vim.command('let l:ret = 3')
+        raise
+
+    del sys.path[0]
+
+    # `ec_` prefix is used in order to keep clean Python namespace
+    ec_data = {}
+
+    def ec_UseConfigFiles():
+        ec_data['filename'] = vim.eval("expand('%:p')")
+        ec_data['conf_file'] = ".editorconfig"
+
+        try:
+            ec_data['options'] = editorconfig.get_properties(ec_data['filename'])
+        except editorconfig_except.EditorConfigError as e:
+            if int(vim.eval('g:EditorConfig_verbose')) != 0:
+                print >> sys.stderr, str(e)
+            return 1
+
+        for key, value in ec_data['options'].items():
+            vim.command("let l:config['" + key.replace("'", "''") + "'] = " +
+                "'" + value.replace("'", "''") + "'")
+
+        return 0
+
+except:
+    pass

--- a/plugin/editorconfig.py
+++ b/plugin/editorconfig.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 try:
     try:
         import vim

--- a/plugin/editorconfig.py
+++ b/plugin/editorconfig.py
@@ -29,7 +29,7 @@ try:
             ec_data['options'] = editorconfig.get_properties(ec_data['filename'])
         except editorconfig_except.EditorConfigError as e:
             if int(vim.eval('g:EditorConfig_verbose')) != 0:
-                print >> sys.stderr, str(e)
+                print(str(e), file=sys.stderr)
             return 1
 
         for key, value in ec_data['options'].items():

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -233,16 +233,18 @@ function! s:InitializePythonBuiltin(editorconfig_core_py_dir) " {{{2
 
     let s:builtin_python_initialized = 1
 
-    let l:ret = 0
     if has('python')
-        execute 'pyfile ' . s:pyscript_path
-        let s:py_eval = 'pyeval'
+        let s:pyfile_cmd = 'pyfile'
+        let s:py_cmd = 'py'
     elseif has ('python3')
-        execute 'py3file ' . s:pyscript_path
-        let s:py_eval = 'py3eval'
+        let s:pyfile_cmd = 'py3file'
+        let s:py_cmd = 'py3'
     else
-        let l:ret = 1
+        return 1
     endif
+
+    let l:ret = 0
+    execute s:pyfile_cmd s:pyscript_path
 
     return l:ret
 endfunction
@@ -367,7 +369,8 @@ function! s:UseConfigFiles_Python_Builtin() " {{{2
 
     let l:config = {}
 
-    let l:ret = eval(s:py_eval . '(''ec_UseConfigFiles()'')')
+    let l:ret = 0
+    execute s:py_cmd 'ec_UseConfigFiles()'
     if l:ret != 0
         return l:ret
     endif


### PR DESCRIPTION
This patch make editorconfig support both python2 and python3.

It seems Python3 support has been considered as tedious.
https://github.com/editorconfig/editorconfig/issues/197
By separating .py file, however, not so messy implementation is possible.