### PR TITLE
Call shellescape() on EditorConfig Core binary

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -389,8 +389,12 @@ endfunction
 function! s:UseConfigFiles_Python_External() " {{{2
 " Use external python interp to run the python EditorConfig Core
 
+    call s:DisableShellSlash()
+
     let l:cmd = shellescape(s:editorconfig_python_interp) . ' ' .
                 \ shellescape(s:editorconfig_core_py_dir . '/main.py')
+
+    call s:ResetShellSlash()
 
     call s:SpawnExternalParser(l:cmd)
 

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -403,7 +403,12 @@ endfunction
 
 function! s:UseConfigFiles_ExternalCommand() " {{{2
 " Use external EditorConfig core (The C core, or editorconfig.py)
-    call s:SpawnExternalParser(s:EditorConfig_exec_path)
+
+    call s:DisableShellSlash()
+    let l:exec_path = shellescape(s:EditorConfig_exec_path)
+    call s:ResetShellSlash()
+
+    call s:SpawnExternalParser(l:exec_path)
 endfunction
 
 function! s:SpawnExternalParser(cmd) " {{{2


### PR DESCRIPTION
This also refactors out the `shellslash` handling into separate functions, extends the changes made in #45 to all `shellslash` modifications, and handles `shellslash` when assembling an external Python command.

Fixes #77.