### PR TITLE
Delay initialization until it is really needed

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -345,11 +345,40 @@ if empty(s:editorconfig_core_mode)
     finish
 endif
 
+function! s:get_filenames(path, filename)
+" Yield full filepath for filename in each directory in and above path
+
+    let l:path_list = []
+    let l:path = a:path
+    while 1
+        let l:path_list += [l:path . '/' . a:filename]
+        let l:newpath = fnamemodify(l:path, ':h')
+        if l:path == l:newpath
+            break
+        endif
+        let l:path = l:newpath
+    endwhile
+    return l:path_list
+endfunction
+
 function! s:UseConfigFiles()
 
     let l:buffer_name = expand('%:p')
     " ignore buffers without a name
     if empty(l:buffer_name)
+        return
+    endif
+
+    " Check if any .editorconfig does exist
+    let l:conf_files = s:get_filenames(expand('%:p:h'), '.editorconfig')
+    let l:conf_found = 0
+    for conf_file in conf_files
+        if filereadable(conf_file)
+            let l:conf_found = 1
+            break
+        endif
+    endfor
+    if !l:conf_found
         return
     endif
 

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -353,7 +353,7 @@ function! s:Initialize() " {{{1
     return 0
 endfunction
 
-function! s:get_filenames(path, filename)
+function! s:GetFilenames(path, filename)
 " Yield full filepath for filename in each directory in and above path
 
     let l:path_list = []
@@ -378,7 +378,7 @@ function! s:UseConfigFiles()
     endif
 
     " Check if any .editorconfig does exist
-    let l:conf_files = s:get_filenames(expand('%:p:h'), '.editorconfig')
+    let l:conf_files = s:GetFilenames(expand('%:p:h'), '.editorconfig')
     let l:conf_found = 0
     for conf_file in conf_files
         if filereadable(conf_file)

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -419,11 +419,6 @@ augroup END
 function! s:UseConfigFiles_Python_Builtin() " {{{2
 " Use built-in python to run the python EditorConfig core
 
-    " ignore buffers that do not have a file path associated
-    if empty(expand('%:p'))
-        return 0
-    endif
-
     let l:config = {}
 
     let l:ret = 0
@@ -467,11 +462,6 @@ function! s:SpawnExternalParser(cmd) " {{{2
 " s:UseConfigFiles_ExternalCommand()
 
     let l:cmd = a:cmd
-
-    " ignore buffers that do not have a file path associated
-    if empty(expand("%:p"))
-        return
-    endif
 
     " if editorconfig is present, we use this as our parser
     if !empty(l:cmd)


### PR DESCRIPTION
This PR is a replacement for #73.

Currently, python is always loaded (when builtin python is used), and this increases startup time of Vim.
This PR delays the initialization and the load of python until it is really needed. This notably decreases startup time.