### PR TITLE
Fix message when trimming line endings

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -617,7 +617,7 @@ function! s:TrimTrailingWhitespace() " {{{{
         " don't lose user position when trimming trailing whitespace
         let s:view = winsaveview()
         try
-            %s/\s\+$//e
+            silent! %s/\s\+$//e
         finally
             call winrestview(s:view)
         endtry


### PR DESCRIPTION
Before:

    3 subtitutions on 3 lines

After:

No message appears