### PR TITLE
Change end_of_line capitalization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-end_of_line = LF
+end_of_line = lf
 charset = utf-8
 max_line_length = 80
 

--- a/plugin/editorconfig-core-py/.editorconfig
+++ b/plugin/editorconfig-core-py/.editorconfig
@@ -4,9 +4,9 @@ root = true
 indent_style = space
 trim_trailing_whitespace = true
 indent_size = 4
-end_of_line = LF
+end_of_line = lf
 
 [*.yml]
 indent_style = space
 indent_size = 2
-end_of_line = LF
+end_of_line = lf

--- a/tests/spec/.editorconfig
+++ b/tests/spec/.editorconfig
@@ -1,4 +1,4 @@
 [*.rb]
 indent_style = space
 indent_size = 2
-end_of_line = LF
+end_of_line = lf


### PR DESCRIPTION
The documentation[1] defines lowercase values. Since this file is
likely to be used as an example or starting point, it's better for it
to follow the convention, even if the uppercase value would also work.

[1] https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties