### PR TITLE
Use keeppatterns with substitute command

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -665,7 +665,7 @@ function! s:TrimTrailingWhitespace() " {{{{
         " don't lose user position when trimming trailing whitespace
         let s:view = winsaveview()
         try
-            silent! %s/\s\+$//e
+            silent! keeppatterns %s/\s\+$//e
         finally
             call winrestview(s:view)
         endtry


### PR DESCRIPTION
**Problem:** the `:substitute` command in the `TrimTrailingWhitespace()` function modifies the search history when executed.  While the behavior of the `n`/`N` commands aren't affected this can cause unexpected behavior with plugins that rely on functions like `histget()` or `histnr()`

**Solution:** use the `keeppatterns` command in the `TrimTrailingWhitespace()` function to prevent editorconfig from unintentionally modifying the search history