### PR TITLE
Don't highlight lines exactly max_line_length long as if they have exceeded max_line_length

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -649,7 +649,7 @@ function! s:ApplyConfig(config) " {{{1
                         endif
                     endfor
                     call matchadd('ColorColumn',
-                        \ '\%' . (l:max_line_length + 1) . 'v', 100)
+                        \ '\%' . (l:max_line_length + 1) . 'v.', 100)
                 endif
             endif
         endif


### PR DESCRIPTION
Update pattern to ignore end-of-line, and avoid marking lines that are
exactly max_line_length long as if they have exceeded max_line_length.