### PR TITLE
Fix cluttering search history by adding `keeppatterns`

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -665,7 +665,7 @@ function! s:TrimTrailingWhitespace() " {{{{
         " don't lose user position when trimming trailing whitespace
         let s:view = winsaveview()
         try
-            silent! %s/\s\+$//e
+            keeppatterns silent! %s/\s\+$//e
         finally
             call winrestview(s:view)
         endtry


### PR DESCRIPTION
`keeppatterns` prevents `\s\+$` line in search history.

![image](https://user-images.githubusercontent.com/10108377/42128653-3f91af28-7cb9-11e8-87f2-07853d058660.png)
> `q/`
