### PR TITLE
Remove backslashes from exclude patterns in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ need to execute `:helptags ALL` so that Vim is aware of editorconfig.txt.
 To ensure that this plugin works well with [Tim Pope's fugitive][], use the
 following patterns array:
 
-    let g:EditorConfig_exclude_patterns = ['fugitive://.\*']
+    let g:EditorConfig_exclude_patterns = ['fugitive://.*']
 
 If you wanted to avoid loading EditorConfig for any remote files over ssh:
 
-    let g:EditorConfig_exclude_patterns = ['scp://.\*']
+    let g:EditorConfig_exclude_patterns = ['scp://.*']
 
 Of course these two items could be combined into the following:
 
-    let g:EditorConfig_exclude_patterns = ['fugitive://.\*', 'scp://.\*']
+    let g:EditorConfig_exclude_patterns = ['fugitive://.*', 'scp://.*']
 
 #### Disable rules
 


### PR DESCRIPTION
These backslashes escape the splats and prevent the exclude patterns from
matching.