### PR TITLE
Stop setting 'softtabstop'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ let g:EditorConfig_disable_rules = ['trim_trailing_whitespace']
 
 You are able to disable any supported EditorConfig properties.
 
+#### A note on 'softtabstop'
+
+Previously, this plugin set 'softtabstop' to the same value as 'shiftwidth'. It no
+longer does. If you want to continue having 'softtabstop' equal to 'shiftwidth', set
+'softtabstop' to a negative number in your vimrc.
+
+Refer to `:help 'softtabstop'`.
+
 ## Bugs and Feature Requests
 
 Feel free to submit bugs, feature requests, and other issues to the

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -387,12 +387,10 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
         " value
         if a:config["indent_size"] == "tab"
             let &l:shiftwidth = &l:tabstop
-            let &l:softtabstop = &l:shiftwidth
         else
             let l:indent_size = str2nr(a:config["indent_size"])
             if l:indent_size > 0
                 let &l:shiftwidth = l:indent_size
-                let &l:softtabstop = &l:shiftwidth
             endif
         endif
 


### PR DESCRIPTION
1. Vim already supports having 'softtabstop' equal to 'shiftwidth'.
2. I think 'softtabstop' is really a UI tweak, not a filetype setting.

This bit me when I finally decided I didn't like softtabstop, and started setting it to 0 in ~/.vimrc. ;)