### PR TITLE
Do not auto-set 'tabstop'

### DIFF
--- a/autoload/editorconfig_core/handler.vim
+++ b/autoload/editorconfig_core/handler.vim
@@ -161,13 +161,6 @@ function! s:preprocess_values(job, opts)
         let a:opts['indent_size'] = 'tab'
     endif
 
-    " Set tab_width to indent_size if indent_size is specified and
-    " tab_width is unspecified
-    if has_key(a:opts, 'indent_size') && !has_key(a:opts, 'tab_width') &&
-                \ get(a:opts, 'indent_size', '') !=? "tab"
-        let a:opts['tab_width'] = a:opts['indent_size']
-    endif
-
     " Set indent_size to tab_width if indent_size is "tab"
     if has_key(a:opts, 'indent_size') && has_key(a:opts, 'tab_width') &&
                 \ get(a:opts, 'indent_size', '') ==? "tab"


### PR DESCRIPTION
'tabstop' is a *visual* setting, not concerned with any vagaries of a
project's indentation wishes.

In fact, one of the great reasons to insist on tab-based indenting is
that every developer can then pick their own tab width!

Sadly, the real world has intervened to make that option intractable,
but editorconfig-vim should nonetheless leave 'tabstop' alone.