### PR TITLE
Can use tests/travis-test.sh to test plugin from command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 tags
 tests/**/build
 tests/**/.bundle
+
+# Editor backup files
+*.swp
+*~
+~*

--- a/tests/plugin/.gitignore
+++ b/tests/plugin/.gitignore
@@ -1,0 +1,2 @@
+# Where bundler installs local Gemfile dependencies
+/vendor/

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -4,21 +4,42 @@
 # Licensed Apache, version 2.0 or any later version, at your option.
 
 # Error exit; debug output
-set -evx
+set -vxEeuo pipefail
 
-if [[ $TEST_WHICH = 'plugin' ]]; then       # test plugin
+# Permit `travis-test.sh plugin` if TEST_WHICH is unset
+if [[ ( ! "${TEST_WHICH:-}" ) && "${1:-}" ]]; then
+    export TEST_WHICH="$1"
+fi
+
+if [[ "$TEST_WHICH" = 'plugin' ]]; then       # test plugin
+
+    # If not running from Travis, do what Travis would have
+    # done for us.
+    if [[ ! "${BUNDLE_GEMFILE:-}" ]]; then
+        here="$(cd "$(dirname "$0")" &>/dev/null ; pwd)"
+        export BUNDLE_GEMFILE="${here}/plugin/Gemfile"
+        # Install into tests/plugin/vendor.  Don't clear it first,
+        # since you can clear it yourself if you're running from a
+        # dev environment.
+        bundle install --jobs=3 --retry=3 --deployment
+    fi
+
     # Use the standalone Vimscript EditorConfig core to test the plugin's
     # external_command mode
     export EDITORCONFIG_VIM_EXTERNAL_CORE=tests/core/editorconfig
 
     bundle exec rspec tests/plugin/spec/editorconfig_spec.rb
 
-else                                        # test core
+elif [[ "$TEST_WHICH" = 'core' ]]; then     # test core
     cd tests/core
-    mkdir build
+    mkdir -p build  # May already exist if running from a dev env
     cd build
     cmake ..
     ctest . --output-on-failure -VV -C Debug
     # -C Debug: for Visual Studio builds, you have to specify
     # a configuration.
+
+else
+    echo 'Invalid TEST_WHICH value' 1>&2
+    exit 1
 fi


### PR DESCRIPTION
Currently, you cannot use `tests/travis-test.sh` to replicate the Travis plugin tests.  This PR fixes that, and also permits you to say `./tests/travis-test.sh plugin` instead of having to set an environment variable first.

Changes:
- Update `tests/travis-test.sh` to be usable from the command line (while in the root of the repo).
- **edit** travis-test.sh: add errexit, pipefail
- Update `tests/plugin/.gitignore` to ignore the `vendor/` tree in which bundles are installed when you do `travis-test.sh plugin`
- Add editor-backup files to main `.gitignore`

I got the Travis information from the log for [this job](https://travis-ci.org/github/editorconfig/editorconfig-vim/jobs/656703513).