### PR TITLE
Conditionally define variables b:editorconfig_invoked and b:editorconfig_had_config

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -197,6 +197,7 @@ function! s:GetFilenames(path, filename) " {{{1
 endfunction " }}}1
 
 function! s:UseConfigFiles() abort " Apply config to the current buffer {{{1
+    let b:editorconfig_tried = 1
     let l:buffer_name = expand('%:p')
     " ignore buffers without a name
     if empty(l:buffer_name)
@@ -242,9 +243,12 @@ function! s:UseConfigFiles() abort " Apply config to the current buffer {{{1
     endfor
 
     if s:editorconfig_core_mode ==? 'vim_core'
-        call s:UseConfigFiles_VimCore()
+        if s:UseConfigFiles_VimCore() == 0
+            let b:editorconfig_applied = 1
+        endif
     elseif s:editorconfig_core_mode ==? 'external_command'
         call s:UseConfigFiles_ExternalCommand()
+        let b:editorconfig_applied = 1
     else
         echohl Error |
                     \ echo "Unknown EditorConfig Core: " .


### PR DESCRIPTION
These can be used to introspect whether editorconfig hooks have run for a buffer
and whether they had any config to apply in order to make downstream heuristic
decisions such as whether to invoke vim-sleuth to guess buffer settings.

Resolves #141.