### PR TITLE
Add the ability to disable EditorConfig per-buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ Of course these two items could be combined into the following:
 let g:EditorConfig_exclude_patterns = ['fugitive://.*', 'scp://.*']
 ```
 
+#### Disable for a specific filetype
+
+Since you can disable this plugin for a specific buffer, you can disable the
+plugin for all buffer of a specific filetype. For example, to disable
+EditorConfig for all git commit messages (filetype `gitcommit`):
+
+```viml
+au FileType gitcommit let b:EditorConfig_disable = 1
+```
+
 #### Disable rules
 
 You might want to override some project-specific EditorConfig rules in global

--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ Use Vundle by adding to your `.vimrc` Vundle plugins section:
 Plugin 'editorconfig/editorconfig-vim'
 ```
 
-Then remember to call `:PluginInstall`.
+Then call `:PluginInstall`.
 
 ### Install with [vim-plug][]
 
 Use vim-plug by adding to your `.vimrc` in your plugin section:
-  
+
 ```viml
 Plug 'editorconfig/editorconfig-vim'
 ```
-  
-Then remember to call `:PlugInstall`.
+
+Then call `:PlugInstall`.
 
 ### No external editorconfig core library is required
 
@@ -69,18 +69,19 @@ The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
 * `tab_width`
 * `end_of_line`
 * `charset`
-* `insert_final_newline` (Feature +fixendofline (available on Vim 7.4.785+) or [PreserveNoEOL][] is required for this property)
+* `insert_final_newline` (Feature `+fixendofline`, available on Vim 7.4.785+,
+  or [PreserveNoEOL][] is required for this property)
 * `trim_trailing_whitespace`
 * `max_line_length`
 * `root` (only used by EditorConfig core)
 
-## Recommended Options
+## Selected Options
 
-All of the options which are supported are documented in [editorconfig.txt][]
+The supported options are documented in [editorconfig.txt][]
 and can be viewed by executing the following: `:help editorconfig`. You may
 need to execute `:helptags ALL` so that Vim is aware of editorconfig.txt.
 
-#### Excluded patterns.
+### Excluded patterns
 
 To ensure that this plugin works well with [Tim Pope's fugitive][], use the
 following patterns array:
@@ -101,21 +102,23 @@ Of course these two items could be combined into the following:
 let g:EditorConfig_exclude_patterns = ['fugitive://.*', 'scp://.*']
 ```
 
-#### Disable for a specific filetype
+### Disable for a specific filetype
 
-Since you can disable this plugin for a specific buffer, you can disable the
-plugin for all buffer of a specific filetype. For example, to disable
+You can disable this plugin for a specific buffer by setting
+`b:EditorConfig_disable`.  Therefore, you can disable the
+plugin for all buffers of a specific filetype. For example, to disable
 EditorConfig for all git commit messages (filetype `gitcommit`):
 
 ```viml
 au FileType gitcommit let b:EditorConfig_disable = 1
 ```
 
-#### Disable rules
+### Disable rules
 
-You might want to override some project-specific EditorConfig rules in global
+In very rare cases,
+you might need to override some project-specific EditorConfig rules in global
 or local vimrc in some cases, e.g., to resolve conflicts of trailing whitespace
-trimming and buffer autosaving.
+trimming and buffer autosaving.  This is not recommended, but you can:
 
 ```viml
 let g:EditorConfig_disable_rules = ['trim_trailing_whitespace']
@@ -126,7 +129,7 @@ You are able to disable any supported EditorConfig properties.
 ## Bugs and Feature Requests
 
 Feel free to submit bugs, feature requests, and other issues to the
-[issue tracker][]. Be sure you have read the [contribution guideline][]!
+[issue tracker][]. Be sure you have read the [contribution guidelines][]!
 
 [EditorConfig]: http://editorconfig.org
 [GitHub]: https://github.com/editorconfig/editorconfig-vim
@@ -135,7 +138,7 @@ Feel free to submit bugs, feature requests, and other issues to the
 [Vim online]: http://www.vim.org/scripts/script.php?script_id=3934
 [Vundle]: https://github.com/gmarik/Vundle.vim
 [archive]: https://github.com/editorconfig/editorconfig-vim/archive/master.zip
-[contribution guideline]: https://github.com/editorconfig/editorconfig/blob/master/CONTRIBUTING.md#submitting-an-issue
+[contribution guidelines]: https://github.com/editorconfig/editorconfig/blob/master/CONTRIBUTING.md#submitting-an-issue
 [issue tracker]: https://github.com/editorconfig/editorconfig-vim/issues
 [pathogen]: https://github.com/tpope/vim-pathogen
 [properties]: http://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -88,11 +88,11 @@ is restarted.
 This is a buffer-local variable that disables the EditorConfig plugin for a
 single buffer.
 
-Example: Disable EditorConfig for a single buffer
+Example: Disable EditorConfig for the current buffer:
 >
  let b:EditorConfig_disable = 1
 <
-Example: Disable EditorConfig for all git commit messages
+Example: Disable EditorConfig for all git commit messages:
 >
  au FileType gitcommit let b:EditorConfig_disable = 1
 <

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -84,6 +84,19 @@ If you choose "external_command" mode, you must also set
 Changes to "g:EditorConfig_core_mode" will not take effect until Vim
 is restarted.
 
+                                            *b:EditorConfig_disable*
+This is a buffer-local variable that disables the EditorConfig plugin for a
+single buffer.
+
+Example: Disable EditorConfig for a single buffer
+>
+ let b:EditorConfig_disable = 1
+<
+Example: Disable EditorConfig for all git commit messages
+>
+ au FileType gitcommit let b:EditorConfig_disable = 1
+<
+
                                             *g:EditorConfig_exclude_patterns*
 This is a list contains file path patterns which will be ignored by
 EditorConfig plugin. When the path of the opened buffer (i.e.

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -203,6 +203,13 @@ function! s:UseConfigFiles() abort " Apply config to the current buffer {{{1
         return
     endif
 
+    if exists("b:EditorConfig_disable") && b:EditorConfig_disable
+        if g:EditorConfig_verbose
+            echo 'Skipping EditorConfig for buffer "' . l:buffer_name . '"'
+        endif
+        return
+    endif
+
     " Check if any .editorconfig does exist
     let l:conf_files = s:GetFilenames(expand('%:p:h'), '.editorconfig')
     let l:conf_found = 0


### PR DESCRIPTION
This PR introduces a buffer-local variable, `b:EditorConfig_disable`, that would allow users to disable EditorConfig for specific filetypes, or create their own rules for disabling.

Solves #104.