### PR TITLE
Add the ability to disable individual rules per-buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ let g:EditorConfig_disable_rules = ['trim_trailing_whitespace']
 
 You are able to disable any supported EditorConfig properties.
 
+Additionally, you can also disable rules for a single buffer, which you can then
+use to disable rules for all buffers of a specific filetype. This can be used to
+prevent EditorConfig from producing broken Makefiles by replacing tabs with
+spaces.
+
+```viml
+au FileType make let b:EditorConfig_disable_rules = ['indent_style']
+```
+
 ## Bugs and Feature Requests
 
 Feel free to submit bugs, feature requests, and other issues to the

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -95,6 +95,29 @@ Example: Avoid loading EditorConfig for any remote files over ssh
  let g:EditorConfig_exclude_patterns = ['scp://.*']
 <
 
+                                            *g:EditorConfig_disable_rules*
+This is a list that contains EditorConfig properties that should be ignored by
+the plugin. This setting only applies when |g:EditorConfig_core_mode| is set
+to "vim_core". The default is an empty list.
+
+Example: Prevent EditorConfig from trimming trailing whitespaces
+>
+ let g:EditorConfig_disable_rules = ['trim_trailing_whitespace']
+<
+
+                                            *b:EditorConfig_disable_rules*
+This is a buffer-local version of |g:EditorConfig_disable_rules|. The
+default is an empty list.
+
+Example: Prevent EditorConfig from replacing tabs with spaces for a single
+buffer
+>
+ let b:EditorConfig_disable_rules = ['indent_style']
+<
+Example: Prevent EditorConfig from replacing tabs with spaces within Makefiles
+>
+ au FileType make let b:EditorConfig_disable_rules = ['indent_style']
+<
                                             *g:EditorConfig_exec_path*
 The file path to the EditorConfig core executable. You can set this value in
 your |vimrc| like this:

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -504,8 +504,11 @@ function! s:TrimTrailingWhitespace() " {{{1
 endfunction " }}}1
 
 function! s:IsRuleActive(name, config) " {{{1
-    return index(g:EditorConfig_disable_rules, a:name) < 0 &&
-                 \ has_key(a:config, a:name)
+    let l:globally_active = index(g:EditorConfig_disable_rules, a:name) < 0
+    let l:locally_active = exists("b:EditorConfig_disable_rules") &&
+                \ index(b:EditorConfig_disable_rules, a:name) < 0
+    let l:has_rule = has_key(a:config, a:name)
+    return l:has_rule && (l:globally_active || l:locally_active)
 endfunction "}}}1
 
 let &cpo = s:saved_cpo


### PR DESCRIPTION
This change introduces a buffer-local version of `g:EditorConfig_disable_rules`. It's useful in cases where EditorConfig
rules are in conflict with the file syntax, e.g. space indents in Makefiles.

Somewhat related to #154 