### PR TITLE
Use keepjumps in TrimTrailingWhitespace

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -503,7 +503,7 @@ function! s:TrimTrailingWhitespace() " {{{1
         " don't lose user position when trimming trailing whitespace
         let s:view = winsaveview()
         try
-            silent! keeppatterns %s/\s\+$//e
+            silent! keeppatterns keepjumps %s/\s\+$//e
         finally
             call winrestview(s:view)
         endtry


### PR DESCRIPTION
Similar to #99, `:s` modifies the jumplist so after `TrimTrailingWhitespace` commands like `CTRL-O` don't behave as expected. `keepjumps` prevents `:s` from changing the jumplist.