### PR TITLE
fix inaccuracy in README (installation process)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use vim-plug by adding to your `.vimrc` in your plugin section:
 Plug 'editorconfig/editorconfig-vim'
 ```
 
-Source your `.vimrc` by calling `:source $MYVIMRC.`
+Source your `.vimrc` by calling `:source $MYVIMRC`.
 
 Then call `:PlugInstall`.
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,7 @@ Use vim-plug by adding to your `.vimrc` in your plugin section:
 Plug 'editorconfig/editorconfig-vim'
 ```
 
-Source your `.vimrc`:
-
-```viml
-source .vimrc
-```
+Source your `.vimrc` by calling `:source $MYVIMRC.`
 
 Then call `:PlugInstall`.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Use vim-plug by adding to your `.vimrc` in your plugin section:
 Plug 'editorconfig/editorconfig-vim'
 ```
 
+Source your `.vimrc`:
+
+```viml
+source .vimrc
+```
+
 Then call `:PlugInstall`.
 
 ### No external editorconfig core library is required


### PR DESCRIPTION
The `.vimrc` needs to be sourced before calling `:PlugInstall`, otherwise newly added plugins won't be installed.