### PR TITLE
Change line colorcolumn setting to not overwrite

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -124,11 +124,11 @@ is restarted.
 
                                             *g:EditorConfig_max_line_indicator*
 The way to show the line where the maximal length is reached. Accepted values
-are "line", "fill", otherwise there will be no max line indicator.
+are "line", "fill" and "exceeding", otherwise there will be no max line
+indicator.
 
     "line":      the right column of the max line length column will be
-                 highlighted, made possible by setting 'colorcolumn' to
-                 "max_line_length + 1".
+                 highlighted, made possible by adding "+1" to 'colorcolumn'.
 
     "fill":      all the columns to the right of the max line length column
                  will be highlighted, made possible by setting 'colorcolumn'

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -473,7 +473,7 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
         if exists('+colorcolumn')
             if l:max_line_length > 0
                 if g:EditorConfig_max_line_indicator == 'line'
-                    let &l:colorcolumn = l:max_line_length + 1
+                    setlocal colorcolumn+=+1
                 elseif g:EditorConfig_max_line_indicator == 'fill' &&
                             \ l:max_line_length < &l:columns
                     " Fill only if the columns of screen is large enough


### PR DESCRIPTION
This changes the modification of the 'colorcolumn' setting to not be
overwritten, but instead expanded when g:EditorConfig_max_line_indicator
is set to "line". This will preserve the previously set value. Also
instead of calculating the column ourselves, we let Vim do it, by adding
"+1" to the colorcolumn setting.

This should fix issue #158.