### PR TITLE
plugin tests: more informative failure messages

### DIFF
--- a/tests/plugin/spec/editorconfig_spec.rb
+++ b/tests/plugin/spec/editorconfig_spec.rb
@@ -18,7 +18,8 @@ def test_editorconfig(vim, file_name, expected_values)
   vim.edit(File.join(BASE_PATH, file_name))
 
   expected_values.each do |key, val|
-    expect(vim.echo("&l:#{key}")).to eq(val)
+    vimval = vim.echo("&l:#{key}")
+    expect(vimval).to eq(val), "key #{key} had value #{vimval}, but I expected #{val}"
   end
 
   vim.command 'bd!'

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -11,6 +11,17 @@ if [[ ( ! "${TEST_WHICH:-}" ) && "${1:-}" ]]; then
     export TEST_WHICH="$1"
 fi
 
+if [[ ! "${TEST_WHICH:-}" ]]; then
+    cat <<EOT
+Usage: $0 \$WHICH
+  or:  TEST_WHICH=\$WHICH $0
+Run automated tests of editorconfig-vim
+
+\$WHICH can be "core" or "plugin".
+EOT
+    exit 2
+fi
+
 if [[ "$TEST_WHICH" = 'plugin' ]]; then       # test plugin
 
     # If not running from Travis, do what Travis would have


### PR DESCRIPTION
When a test fails, show the name of the key that failed as well as the value of that key.

Currently, you see the value, but not which key it was.  This PR fixes that.