### PR TITLE
Stop changing 'encoding'

### DIFF
--- a/autoload/editorconfig_core/ini.vim
+++ b/autoload/editorconfig_core/ini.vim
@@ -60,23 +60,24 @@ lockvar s:SECTCRE s:OPTCRE s:MAX_SECTION_NAME s:MAX_PROPERTY_NAME s:MAX_PROPERTY
 " Read \p config_filename and return the options applicable to
 " \p target_filename.  This is the main entry point in this file.
 function! editorconfig_core#ini#read_ini_file(config_filename, target_filename)
-    let l:oldenc = &encoding
-
     if !filereadable(a:config_filename)
         return {}
     endif
 
-    try     " so &encoding will always be reset
-        let &encoding = 'utf-8'     " so readfile() will strip BOM
+    try
         let l:lines = readfile(a:config_filename)
+        if &encoding !=? 'utf-8'
+            " strip BOM
+            if len(l:lines) > 0 && l:lines[0][:2] ==# "\xEF\xBB\xBF"
+                let l:lines[0] = l:lines[0][3:]
+            endif
+        endif
         let result = s:parse(a:config_filename, a:target_filename, l:lines)
     catch
-        let &encoding = l:oldenc
         " rethrow, but with a prefix since throw 'Vim...' fails.
         throw 'Could not read editorconfig file at ' . v:throwpoint . ': ' . string(v:exception)
     endtry
 
-    let &encoding = l:oldenc
     return result
 endfunction
 

--- a/autoload/editorconfig_core/ini.vim
+++ b/autoload/editorconfig_core/ini.vim
@@ -71,6 +71,8 @@ function! editorconfig_core#ini#read_ini_file(config_filename, target_filename)
             if len(l:lines) > 0 && l:lines[0][:2] ==# "\xEF\xBB\xBF"
                 let l:lines[0] = l:lines[0][3:]
             endif
+            " convert from UTF-8 to 'encoding'
+            call map(l:lines, 'iconv(v:val, "utf-8", &encoding)')
         endif
         let result = s:parse(a:config_filename, a:target_filename, l:lines)
     catch

--- a/tests/plugin/spec/editorconfig_spec.rb
+++ b/tests/plugin/spec/editorconfig_spec.rb
@@ -160,3 +160,10 @@ if extcore
   )
   test_instance vim
 end
+
+# Test the vim core with latin1 encoding
+(lambda do
+  puts 'Testing with express vim_core mode'
+  vim = create_vim("set encoding=latin1")
+  test_instance vim
+end).call


### PR DESCRIPTION
Changing 'encoding' has many side effects and that should be avoided.
Strip BOM manually.

Fix #144
Fix #145
Fix #147