### PR TITLE
Don't skip acwrite buffers

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -534,7 +534,7 @@ endfunction
 
 function! s:ApplyConfig(config) " {{{1
     " Only process normal buffers (do not treat help files as '.txt' files)
-    if !empty(&buftype)
+    if index(['', 'acwrite'], &buftype) == -1
         return
     endif
 


### PR DESCRIPTION
Prior to this change, the editorconfig-vim will skip processing any
non-'normal' buffer, and the idea behind this is that we would not want
it to mess around with, say, 'help' or 'quickfix' buffers.

However, 'acwrite' buffers act pretty much like any other 'normal'
buffer, with custom filetypes and all; the only difference is that
'acwrite' buffers will always be writtein with BufWriteCmd autocommands
(see `:h buftype`).

Because of this, I have changed editorconfig-vim to skip processing
buffers which are not 'normal' (i.e., empty buftype), or 'acwrite'.