### PR TITLE
Fix &fileencoding changed to utf-8 upon :e

### DIFF
--- a/autoload/editorconfig_core/ini.vim
+++ b/autoload/editorconfig_core/ini.vim
@@ -67,7 +67,8 @@ function! editorconfig_core#ini#read_ini_file(config_filename, target_filename)
     endif
 
     try     " so &encoding will always be reset
-        let &encoding = 'utf-8'     " so readfile() will strip BOM
+        " Note: 'let &enc' has side effects on &fenc
+        set encoding = 'utf-8'     " so readfile() will strip BOM
         let l:lines = readfile(a:config_filename)
         let result = s:parse(a:config_filename, a:target_filename, l:lines)
     catch


### PR DESCRIPTION
For some reason, this plugin is causing `:e` to change the file's encoding option (`&fileencoding`) to utf-8, overriding whatever it's currently set to.

This doesn't happen upon **first** opening the file, but **only** upon re-opening it with `:e`. Probably because the script executes before

This weird fix works apparently due to some weird vim internal discrepancy between how `set enc` and `let &enc` work. Using `let` seems to *also* mess with the file's encoding (`&fileencoding`).

I should mention I was editing a file that did not have any .editorconfig settings applied to it.

## Steps to reproduce:

1. Open and save a file in latin1 mode:
```sh
export LANG=en_US LC_ALL=en_US LC_CTYPE=en_US
vim foo.txt
:set fenc=latin1
:w
```
2. Without closing Vim, reload the file:
```
:e
```
3. Check the file encoding hasn't changed:
```
:echo &fenc
```

`&fenc` should still be `latin1`. If it was reset to `utf-8` the issue persists.

Closes #145 