### PR TITLE
Call setl [no]endofline using insert_final_newline

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -445,6 +445,11 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
     augroup END
 
     if s:IsRuleActive('insert_final_newline', a:config)
+        if a:config["insert_final_newline"] == "false"
+            setl noendofline
+        else
+            setl endofline
+        endif
         if exists('+fixendofline')
             if a:config["insert_final_newline"] == "false"
                 setl nofixendofline


### PR DESCRIPTION
When I use `:r testname.out` to read the lines of a file (where testname.out has no trailing newline)
into the end of a file or replace the end of a file (e.g. testname.phpt with `--EXPECT--` or `--OUTPUT--` sections), and the `binary` option was set
(I think I set that years ago for php files, ~~for editing tests containing binary non-utf8 data?~~ as a workaround to avoid diff noise when changing newlines in files in existing projects with no coding standards. This predated vim's support for fixendofline.),
the resulting file has no newline when saving without `setl endofline`.

EDIT: In the vast majority of use cases, enabling endofline for modern vim and overriding the binary setting seems like a mistake (e.g. most users would be opening binary file formats). I had `au FileType php setlocal binary` set years ago and should remove that.

```
vim help text:
'endofline' 'eol'	boolean	(default on)
			local to buffer
	When writing a file and this option is off and the 'binary' option
	is on, or 'fixeol' option is off, no <EOL> will be written for the
	last line in the file.  This option is automatically set or reset when
	starting to edit a new file, depending on whether file has an <EOL>
	for the last line in the file.  Normally you don't have to set or
	reset this option.
	When 'binary' is off and 'fixeol' is on the value is not used when
	writing the file.  When 'binary' is on or 'fixeol' is off it is used
	to remember the presence of a <EOL> for the last line in the file, so
	that when you write the file the situation from the original file can
	be kept.  But you can change it if you want to.

```

(This is checked outside of exists('+fixendofline'), to also work in older vim releases)

Alternative to #174