### PR TITLE
Permit disabling softtabstop control, as softtabstop is a Vim-specific feature not supported by EditorConfig

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -167,7 +167,8 @@ backspace key delete one indent level. If you turn off that feature (by
 setting the option to 0), only a single space will be deleted.
 This option defaults to 1, which enables 'softtabstop' and uses the
 'shiftwidth' value for it. You can also set this to -1 to automatically follow
-the current 'shiftwidth' value (since Vim 7.3.693).
+the current 'shiftwidth' value (since Vim 7.3.693). Or set this to [] if
+EditorConfig should not touch 'softtabstop' at all.
 
                                             *g:EditorConfig_softtabstop_tab*
 When tabs are used for indent, Vim's 'softtabstop' feature only applies to
@@ -175,6 +176,7 @@ backspacing over existing runs of spaces.
 This option defaults to 1, so backspace will delete one indent level worth of
 spaces; -1 does the same but automatically follows the current 'shiftwidth'
 value. Set this to 0 to have backspace delete just a single space character.
+Or set this to [] if EditorConfig should not touch 'softtabstop' at all.
 
                                             *g:EditorConfig_verbose*
 Set this to 1 if you want debug info printed:

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -161,6 +161,21 @@ max_line_length is set:
 <
 This option defaults to 0.
 
+                                            *g:EditorConfig_softtabstop_space*
+When spaces are used for indent, Vim's 'softtabstop' feature will make the
+backspace key delete one indent level. If you turn off that feature (by
+setting the option to 0), only a single space will be deleted.
+This option defaults to 1, which enables 'softtabstop' and uses the
+'shiftwidth' value for it. You can also set this to -1 to automatically follow
+the current 'shiftwidth' value (since Vim 7.3.693).
+
+                                            *g:EditorConfig_softtabstop_tab*
+When tabs are used for indent, Vim's 'softtabstop' feature only applies to
+backspacing over existing runs of spaces.
+This option defaults to 1, so backspace will delete one indent level worth of
+spaces; -1 does the same but automatically follows the current 'shiftwidth'
+value. Set this to 0 to have backspace delete just a single space character.
+
                                             *g:EditorConfig_verbose*
 Set this to 1 if you want debug info printed:
 >

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -402,14 +402,18 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
         " value
         if a:config["indent_size"] == "tab"
             let &l:shiftwidth = &l:tabstop
-            let &l:softtabstop = g:EditorConfig_softtabstop_tab > 0 ?
-                        \ &l:shiftwidth : g:EditorConfig_softtabstop_tab
+            if type(g:EditorConfig_softtabstop_tab) != type([])
+                let &l:softtabstop = g:EditorConfig_softtabstop_tab > 0 ?
+                            \ &l:shiftwidth : g:EditorConfig_softtabstop_tab
+            endif
         else
             let l:indent_size = str2nr(a:config["indent_size"])
             if l:indent_size > 0
                 let &l:shiftwidth = l:indent_size
-                let &l:softtabstop = g:EditorConfig_softtabstop_space > 0 ?
-                        \ &l:shiftwidth : g:EditorConfig_softtabstop_space
+                if type(g:EditorConfig_softtabstop_space) != type([])
+                    let &l:softtabstop = g:EditorConfig_softtabstop_space > 0 ?
+                            \ &l:shiftwidth : g:EditorConfig_softtabstop_space
+                endif
             endif
         endif
 

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -60,6 +60,14 @@ if !exists('g:EditorConfig_disable_rules')
     let g:EditorConfig_disable_rules = []
 endif
 
+if !exists('g:EditorConfig_softtabstop_space')
+    let g:EditorConfig_softtabstop_space = 1
+endif
+
+if !exists('g:EditorConfig_softtabstop_tab')
+    let g:EditorConfig_softtabstop_tab = 1
+endif
+
 " Copy some of the globals into script variables --- changes to these
 " globals won't affect the plugin until the plugin is reloaded.
 if exists('g:EditorConfig_core_mode') && !empty(g:EditorConfig_core_mode)
@@ -394,12 +402,14 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
         " value
         if a:config["indent_size"] == "tab"
             let &l:shiftwidth = &l:tabstop
-            let &l:softtabstop = &l:shiftwidth
+            let &l:softtabstop = g:EditorConfig_softtabstop_tab > 0 ?
+                        \ &l:shiftwidth : g:EditorConfig_softtabstop_tab
         else
             let l:indent_size = str2nr(a:config["indent_size"])
             if l:indent_size > 0
                 let &l:shiftwidth = l:indent_size
-                let &l:softtabstop = &l:shiftwidth
+                let &l:softtabstop = g:EditorConfig_softtabstop_space > 0 ?
+                        \ &l:shiftwidth : g:EditorConfig_softtabstop_space
             endif
         endif
 


### PR DESCRIPTION
The `softtabstop` setting is meant to be used with a value that is different from the `tabstop` setting (and `tabstop` typically then kept at the default 8), and then renders the indent first with hard tabs, filling remaining differences with spaces. Though this has some nice editing characteristics (no messing with tabstop values but still getting cursor progressing to certain columns), it is quite specific to Vim and hasn't caught on elsewhere. Therefore, the EditorConfig spec doesn't support this feature.

The existing implementation sets `softtabstop` to the `tabstop` / indent size, effectively turning off the feature completely. That is not wrong. However, Vim documents that the feature is turned off by a value of 0; a value equal to `tabstop` and `shiftwidth` effectively turns off the feature as well. The difference matters when hard tabs are configured and the user (maybe temporarily) manually adjusts the size of an indent by changing the `tabstop` (and `shiftwidth`) values. Suddenly, `tabstop` is different than `softtabstop`, and Vim starts inserting the mix of tabs and spaces that the softtabstop feature is about! Also, some plugins or statuslines may wrongly interpret the positive `softtabstop` value to indicate activation of the softtabstop feature, even though it's effectively off.

This change is related to #137; however, instead of dropping the modification of `softtabstop` altogether, I think it's better to reset `softtabstop` to 0, to avoid the potential bad effects just mentioned. Users may have globally turned `softtabstop` on, and that global value would then still be inherited into buffers under control of EditorConfig configurations.
