### PR TITLE
On Windows, skip the test that makes Appveyor hang

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,12 +96,10 @@ test_script:
   # Run the core tests
   - ctest . --output-on-failure -C Debug
 
-  # CTestCustom specifies skipping UTF-8 tests on Windows.
-  - cmd: echo "Reminder - did not try UTF-8"
-  - sh: echo "Reminder - tried UTF-8"
+  # CTestCustom specifies skipping some tests on Windows.
+  - cmd: echo "Reminder - skipped some tests"
 
 on_failure:
   - echo "failed"
   - cmd: type tests\core\build\Testing\Temporary\LastTest.log
   - sh: cat tests/core/build/Testing/Temporary/LastTest.log
-

--- a/tests/core/CTestCustom.cmake
+++ b/tests/core/CTestCustom.cmake
@@ -32,3 +32,10 @@ if(WIN32 AND (NOT "$ENV{RUN_UTF8}"))
     set(CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} g_utf_8_char)
     set(CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} utf_8_char)
 endif()
+
+# Skip min_supported_value_length on Windows since that test seems to
+# cause Appveyor to hang.
+if(WIN32)
+    message(WARNING "Skipping min_supported_value_length test on this platform")
+    set(CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} min_supported_value_length)
+endif()


### PR DESCRIPTION
Skip `min_supported_value_length` on Windows.  That test never completes ([example](https://ci.appveyor.com/project/xuhdev/editorconfig-vim/builds/46006489/job/yyupyg9xgwty4weg)).

Fixes #200 well enough :) .