### PR TITLE
Add "fillexceeding" option for max line indicator

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -128,12 +128,12 @@ are "line", "fill", "exceeding" and "fillexceeding", otherwise there will be
 no max line indicator.
 
     "line":          the right column of the max line length column will be
-                     highlighted, by adding "+1" to 'colorcolumn'.
+                     highlighted on all lines, by adding +1 to 'colorcolumn'.
 
     "fill":          all the columns to the right of the max line length
-                     column will be highlighted, by setting 'colorcolumn' to
-                     a list of numbers starting from "max_line_length + 1" to
-                     the number of columns on the screen.
+                     column will be highlighted on all lines, by setting
+                     'colorcolumn' to a list starting from "max_line_length +
+                     1" to the number of columns on the screen.
 
     "exceeding":     the right column of the max line length column will be
                      highlighted on lines that exceed the max line length, by
@@ -143,10 +143,9 @@ no max line indicator.
                      column will be highlighted on lines that exceed the max
                      line length, by adding a match for the ColorColumn group.
 
-    "none":          no max line length indicator will be shown. This is the
-                     recommended value when you do not want any indicator to
-                     be shown, but values other than "line" or "fill" would
-                     also work as "none".
+    "none":          no max line length indicator will be shown. Recommended
+                     when you do not want any indicator to be shown, but any
+                     value other than those listed above also work as "none".
 
 To set this option, add any of the following lines to your |vimrc| file:
 >

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -124,25 +124,29 @@ is restarted.
 
                                             *g:EditorConfig_max_line_indicator*
 The way to show the line where the maximal length is reached. Accepted values
-are "line", "fill" and "exceeding", otherwise there will be no max line
-indicator.
+are "line", "fill", "exceeding" and "fillexceeding", otherwise there will be
+no max line indicator.
 
-    "line":      the right column of the max line length column will be
-                 highlighted, made possible by adding "+1" to 'colorcolumn'.
+    "line":           the right column of the max line length column will be
+                      highlighted, by adding "+1" to 'colorcolumn'.
 
-    "fill":      all the columns to the right of the max line length column
-                 will be highlighted, made possible by setting 'colorcolumn'
-                 to a list of numbers starting from "max_line_length + 1" to
-                 the number of columns on the screen.
+    "fill":           all the columns to the right of the max line length column
+                      will be highlighted, by setting 'colorcolumn' to a list
+                      of numbers starting from "max_line_length + 1" to the
+                      number of columns on the screen.
 
-    "exceeding": the right column of the max line length column will be
-                 highlighted on lines that exceed the max line length, made
-                 possible by adding a match for the ColorColumn group.
+    "exceeding":      the right column of the max line length column will be
+                      highlighted on lines that exceed the max line length, by
+                      adding a match for the ColorColumn group.
 
-    "none":      no max line length indicator will be shown. This is the
-                 recommended value when you do not want any indicator to be
-                 shown, but values other than "line" or "fill" would also work
-                 as "none".
+    "fillexceeding" : all the columns to the right of the max line length column
+                      will be highlighted on lines that exceed the max line
+                      length, by adding a match for the ColorColumn group.
+
+    "none":           no max line length indicator will be shown. This is the
+                      recommended value when you do not want any indicator to
+                      be shown, but values other than "line" or "fill" would
+                      also work as "none".
 
 To set this option, add any of the following lines to your |vimrc| file:
 >

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -127,26 +127,26 @@ The way to show the line where the maximal length is reached. Accepted values
 are "line", "fill", "exceeding" and "fillexceeding", otherwise there will be
 no max line indicator.
 
-    "line":           the right column of the max line length column will be
-                      highlighted, by adding "+1" to 'colorcolumn'.
+    "line":          the right column of the max line length column will be
+                     highlighted, by adding "+1" to 'colorcolumn'.
 
-    "fill":           all the columns to the right of the max line length column
-                      will be highlighted, by setting 'colorcolumn' to a list
-                      of numbers starting from "max_line_length + 1" to the
-                      number of columns on the screen.
+    "fill":          all the columns to the right of the max line length
+                     column will be highlighted, by setting 'colorcolumn' to
+                     a list of numbers starting from "max_line_length + 1" to
+                     the number of columns on the screen.
 
-    "exceeding":      the right column of the max line length column will be
-                      highlighted on lines that exceed the max line length, by
-                      adding a match for the ColorColumn group.
+    "exceeding":     the right column of the max line length column will be
+                     highlighted on lines that exceed the max line length, by
+                     adding a match for the ColorColumn group.
 
-    "fillexceeding" : all the columns to the right of the max line length column
-                      will be highlighted on lines that exceed the max line
-                      length, by adding a match for the ColorColumn group.
+    "fillexceeding": all the columns to the right of the max line length
+                     column will be highlighted on lines that exceed the max
+                     line length, by adding a match for the ColorColumn group.
 
-    "none":           no max line length indicator will be shown. This is the
-                      recommended value when you do not want any indicator to
-                      be shown, but values other than "line" or "fill" would
-                      also work as "none".
+    "none":          no max line length indicator will be shown. This is the
+                     recommended value when you do not want any indicator to
+                     be shown, but values other than "line" or "fill" would
+                     also work as "none".
 
 To set this option, add any of the following lines to your |vimrc| file:
 >

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -502,6 +502,15 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
                     endfor
                     call matchadd('ColorColumn',
                         \ '\%' . (l:max_line_length + 1) . 'v.', 100)
+                elseif g:EditorConfig_max_line_indicator == 'fillexceeding'
+                    let &l:colorcolumn = ''
+                    for l:match in getmatches()
+                        if get(l:match, 'group', '') == 'ColorColumn'
+                            call matchdelete(get(l:match, 'id'))
+                        endif
+                    endfor
+                    call matchadd('ColorColumn',
+                        \ '\%'. (l:max_line_length + 1) . 'v.\+', -1)
                 endif
             endif
         endif


### PR DESCRIPTION
The "exceeding" indicator can be hard to notice as it fills just one column on lines that exceed the max line length. To address this, add a new indicator option "fillexceeding", which fills all the columns that exceed the max length.

I've been using this snippet for years in my vimrc, but making it work with editorconfig is messy as the custom highlighting needs to be applied after editorconfig has changed textwidth (i.e. autocmds are required). It would be nice if editorconfig-vim just supported something similar. I suppose another option would be for editorconfig to allow the calling of a custom function to highlight long lines.