### PR TITLE
Fix overriding the default filetype detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ To install this plugin, you can use one of the following ways:
 
 Download the [archive][] and extract it into your Vim runtime directory
 (`~/.vim` on UNIX/Linux and `$VIM_INSTALLATION_FOLDER\vimfiles` on windows).
-You should have 3 sub-directories in this runtime directory now: "autoload",
-"doc" and "plugin".
+You should have 4 sub-directories in this runtime directory now: "autoload",
+"doc", "ftdetect" and "plugin".
 
 ### Install as Vim8 plugin
 

--- a/ftdetect/editorconfig.vim
+++ b/ftdetect/editorconfig.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead .editorconfig setfiletype=dosini

--- a/mkzip.sh
+++ b/mkzip.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-zip -r editorconfig-vim-$*.zip plugin/* autoload/* doc/*
+zip -r editorconfig-vim-$*.zip autoload/* doc/* ftdetect/* plugin/*

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -285,12 +285,6 @@ command! EditorConfigReload call s:UseConfigFiles() " Reload EditorConfig files
 " On startup, enable the autocommands
 call s:EditorConfigEnable(1)
 
-" Always set the filetype for .editorconfig files
-augroup editorconfig_dosini
-    autocmd!
-    autocmd BufNewFile,BufRead .editorconfig set filetype=dosini
-augroup END
-
 " }}}1
 
 " UseConfigFiles function for different modes {{{1


### PR DESCRIPTION
Vim recognizes the filetype of .editorconfig as editorconfig, not dosini, by default since patch-9.0.1167. It's a superset of the dosini syntax. However editorconfig.vim always overrides it with dosini. To fix this, set the filetype only if Vim hasn't set it yet.