### PR TITLE
Support spelling_language property

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
   or [PreserveNoEOL][] is required for this property)
 * `trim_trailing_whitespace`
 * `max_line_length`
+* `spelling_language`
 * `root` (only used by EditorConfig core)
 
 ## Selected Options

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -580,6 +580,10 @@ function! s:ApplyConfig(bufnr, config) abort
         endif
     endif
 
+    if s:IsRuleActive('spelling_language', a:config)
+        let &l:spelllang=s:ConvertLanguage(a:config['spelling_language'])
+    endif
+
     call editorconfig#ApplyHooks(a:config)
 endfunction
 
@@ -606,4 +610,16 @@ endfunction "}}}1
 let &cpo = s:saved_cpo
 unlet! s:saved_cpo
 
+" {{{
+function! s:ConvertLanguage(language)
+    " Only accept xx or xx-YY language codes (as per editorconfig specification)
+    if a:language =~ '^[a-z]\{2}\(-[A-Z]\{2}\)\?$'
+        " Convert to vim-style xx_yy
+        return tolower(substitute(a:language, "-", "_", ""))
+    elseif g:EditorConfig_verbose
+        echom "'" . a:language . "'' does not match specification for spelling_language. Try 'en' or 'en-GB'"
+        return ""
+    endif
+endfunction
+" }}}
 " vim: fdm=marker fdc=3


### PR DESCRIPTION
I implemented the discussion in https://github.com/editorconfig/editorconfig/issues/315 . Perhaps this is the wrong way around - it should be put in the standard first. But I don't know how to edit the standard, I know how to edit the implementation.

I'm currently running off my own fork, but in case the standard is updated at least this practical implementation is ready.