### PR TITLE
Fix syntax of autocmd for .editorconfig

### DIFF
--- a/ftdetect/editorconfig.vim
+++ b/ftdetect/editorconfig.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead .editorconfig setfiletype=dosini
+autocmd BufNewFile,BufRead .editorconfig setfiletype dosini


### PR DESCRIPTION
Commit 39bd110f adjusted how fallback of .editorconfig filetype should be done, but with vim 9.0 patch 1 (as in Ubuntu 20.04) this rule applies and the syntax glitch is exposed: `setfiletype` is a command, not an option, so takes a parameter instead of being assigned a value.