### PR TITLE
Ignore netrw buffers

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -383,6 +383,11 @@ function! s:ApplyConfig(config) abort " Set the buffer options {{{1
         return
     endif
 
+    " Do not process netrw buffers
+    if &b:filetype == 'netrw'
+        return
+    endif
+
     if g:EditorConfig_verbose
         echo 'Options: ' . string(a:config)
     endif


### PR DESCRIPTION
Previously, when starting Neovim with a directory, opening a netrw buffer, it would encounter the following errors when trying to close (:q):

```
E37: No write since last change
E162: No write since last change for buffer "…"
```

Since editorconfig is concerned with source files, not directory listings (as in the case of netrw buffers), I thought it makes sense to not apply the config for such buffers.

For further details of the issue and my investigation, please see: #212

Thank you so much for this awesome project. 💚 