### PR TITLE
Set shiftwidth to 0 (defaults to tabstop value)

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -149,23 +149,6 @@ max_line_length is set:
 <
 This option defaults to 0.
 
-                                            *g:EditorConfig_softtabstop_space*
-When spaces are used for indent, Vim's 'softtabstop' feature will make the
-backspace key delete one indent level. If you turn off that feature (by
-setting the option to 0), only a single space will be deleted.
-This option defaults to 1, which enables 'softtabstop' and uses the
-'shiftwidth' value for it. You can also set this to -1 to automatically follow
-the current 'shiftwidth' value (since Vim 7.3.693). Or set this to [] if
-EditorConfig should not touch 'softtabstop' at all.
-
-                                            *g:EditorConfig_softtabstop_tab*
-When tabs are used for indent, Vim's 'softtabstop' feature only applies to
-backspacing over existing runs of spaces.
-This option defaults to 1, so backspace will delete one indent level worth of
-spaces; -1 does the same but automatically follows the current 'shiftwidth'
-value. Set this to 0 to have backspace delete just a single space character.
-Or set this to [] if EditorConfig should not touch 'softtabstop' at all.
-
                                             *g:EditorConfig_verbose*
 Set this to 1 if you want debug info printed:
 >

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -64,14 +64,6 @@ if !exists('g:EditorConfig_enable_for_new_buf')
     let g:EditorConfig_enable_for_new_buf = 0
 endif
 
-if !exists('g:EditorConfig_softtabstop_space')
-    let g:EditorConfig_softtabstop_space = 1
-endif
-
-if !exists('g:EditorConfig_softtabstop_tab')
-    let g:EditorConfig_softtabstop_tab = 1
-endif
-
 " Copy some of the globals into script variables --- changes to these
 " globals won't affect the plugin until the plugin is reloaded.
 if exists('g:EditorConfig_core_mode') && !empty(g:EditorConfig_core_mode)
@@ -454,38 +446,26 @@ function! s:ApplyConfig(bufnr, config) abort
         endif
     endif
 
-    " Set tabstop.  Skip this for terminal buffers, e.g., :FZF (#224).
-    if s:IsRuleActive('tab_width', a:config) && bufname(a:bufnr) !~# '^!\w*sh$'
-        let l:tabstop = str2nr(a:config["tab_width"])
-        call setbufvar(a:bufnr, '&tabstop', l:tabstop)
-    else
-        " Grab the current ts so we can use it below
-        let l:tabstop = getbufvar(a:bufnr, '&tabstop')
-    endif
-
-    if s:IsRuleActive('indent_size', a:config)
-        " if indent_size is 'tab', set shiftwidth to tabstop;
-        " if indent_size is a positive integer, set shiftwidth to the integer
-        " value
-        if a:config["indent_size"] == "tab"
-            call setbufvar(a:bufnr, '&shiftwidth', l:tabstop)
-            if type(g:EditorConfig_softtabstop_tab) != type([])
-                call setbufvar(a:bufnr, '&softtabstop',
-                            \ g:EditorConfig_softtabstop_tab > 0 ?
-                            \ l:tabstop : g:EditorConfig_softtabstop_tab)
-            endif
-        else
+    " Skip terminal buffers as setting tabstop affects cursor position (#224).
+    if s:IsRuleActive('indent_size', a:config) && bufname(a:bufnr) !~# '^!\w*sh$'
+        " When shiftwidth is 0 it uses the value of tabstop
+        call setbufvar(a:bufnr, '&shiftwidth', 0)
+        " Disable softtabstop so it doesn't conflict with editorconfig
+        " indentation settings
+        call setbufvar(a:bufnr, '&softtabstop', 0)
+        if a:config["indent_size"] != "tab"
             let l:indent_size = str2nr(a:config["indent_size"])
             if l:indent_size > 0
-                call setbufvar(a:bufnr, '&shiftwidth', l:indent_size)
-                if type(g:EditorConfig_softtabstop_space) != type([])
-                    call setbufvar(a:bufnr, '&softtabstop',
-                            \ g:EditorConfig_softtabstop_space > 0 ?
-                            \ l:indent_size : g:EditorConfig_softtabstop_space)
-                endif
+                call setbufvar(a:bufnr, '&tabstop', l:indent_size)
             endif
         endif
+    endif
 
+    " Set tabstop.  Skip this for terminal buffers, e.g., :FZF (#224).
+    if s:IsRuleActive('tab_width', a:config) && bufname(a:bufnr) !~# '^!\w*sh$'
+        if a:config["indent_style"] == "tab"
+            call setbufvar(a:bufnr, '&tabstop', str2nr(a:config["tab_width"]))
+        endif
     endif
 
     if s:IsRuleActive('end_of_line', a:config) &&

--- a/tests/plugin/spec/editorconfig_spec.rb
+++ b/tests/plugin/spec/editorconfig_spec.rb
@@ -35,7 +35,8 @@ def test_instance(vim)
       it '3_space.py' do
         test_editorconfig vim, '3_space.txt',
           expandtab: '1',
-          shiftwidth: '3',
+          shiftwidth: '0',
+          softtabstop: '0',
           tabstop: '3'
       end
     end
@@ -43,14 +44,16 @@ def test_instance(vim)
     it '4_space.py' do
       test_editorconfig vim, '4_space.py',
         expandtab: '1',
-        shiftwidth: '4',
-        tabstop: '8'
+        shiftwidth: '0',
+        softtabstop: '0',
+        tabstop: '4'
     end
 
     it 'space.txt' do
       test_editorconfig vim, 'space.txt',
         expandtab: '1',
-        shiftwidth: vim.echo('&l:tabstop')
+        shiftwidth: '0',
+        softtabstop: '0'
     end
 
     it 'tab.txt' do
@@ -61,14 +64,16 @@ def test_instance(vim)
     it '4_tab.txt' do
       test_editorconfig vim, '4_tab.txt',
         expandtab: '0',
-        shiftwidth: '4',
+        shiftwidth: '0',
+        softtabstop: '0',
         tabstop: '4'
     end
 
     it '4_tab_width_of_8' do
       test_editorconfig vim, '4_tab_width_of_8.txt',
         expandtab: '0',
-        shiftwidth: '4',
+        shiftwidth: '0',
+        softtabstop: '0',
         tabstop: '8'
     end
 


### PR DESCRIPTION
The current behavior is to set both shiftwidth and tabstop/softtabstop.
shiftwidth gets set to the same value as tabstop. If I open a file that
editorconfig indents with 8-space hard tabs, then ":set tabstop=4", my
shiftwidth will still be 8, meaning that when I indent I will get two
tabs. Set shiftwidth to 0, which defaults to the value of tabstop, and
disable softtabstop so it doesn't conflict. This should have the same
end result with less complication.

This removes the g:EditorConfig_softtabstop_space and
g:EditorConfig_softtabstop_tab options. Users who want to delete
multiple spaces as a single character can enable smarttab.