### PR TITLE
Add example for fillexceeding max_line_indicator to docs

### DIFF
--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -152,6 +152,7 @@ To set this option, add any of the following lines to your |vimrc| file:
  let g:EditorConfig_max_line_indicator = "line"
  let g:EditorConfig_max_line_indicator = "fill"
  let g:EditorConfig_max_line_indicator = "exceeding"
+ let g:EditorConfig_max_line_indicator = "fillexceeding"
  let g:EditorConfig_max_line_indicator = "none"
 <
 The default value is "line".


### PR DESCRIPTION
Sorry, I missed this when adding the new option value