### PR TITLE
Fix warning text found after endfunction when verbose non-zero

### DIFF
--- a/autoload/editorconfig_core/ini.vim
+++ b/autoload/editorconfig_core/ini.vim
@@ -190,7 +190,7 @@ function! s:parse(config_filename, target_filename, lines)
     endif
 
     return {'root': l:is_root, 'options': l:options}
-endfunction!
+endfunction
 
 " }}}1
 " === Helpers =========================================================== {{{1


### PR DESCRIPTION
Related to https://github.com/editorconfig/editorconfig-vim/issues/221.

The argument after endfunction can only be (from `:h :endfunction`):
- `|` command: command to execute next
- `\n` command: command to execute next
- `"` comment: always ignored
- anything else: ignored, warning given when 'verbose' is non-zero

Not really solving the main issue on https://github.com/editorconfig/editorconfig-vim/issues/221, just trying to clean up unnecessary warning message when using verbose option.