### PR TITLE
Don't set tabstop in shell buffers (#224)

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -454,7 +454,8 @@ function! s:ApplyConfig(bufnr, config) abort
         endif
     endif
 
-    if s:IsRuleActive('tab_width', a:config)
+    " Set tabstop.  Skip this for terminal buffers, e.g., :FZF (#224).
+    if s:IsRuleActive('tab_width', a:config) && bufname(l:bufnr) !~# '^!\w*sh$'
         let l:tabstop = str2nr(a:config["tab_width"])
         call setbufvar(a:bufnr, '&tabstop', l:tabstop)
     else


### PR DESCRIPTION
:FZF opens a terminal in the same window as the current buffer, and setbufvar(tabstop) affects the cursor position in the current buffer as well as the cursor position in the terminal buffer.

To avoid that, don't set tabstop in terminal windows running shells.

Fixes #224 (at least by working around the issue)