### PR TITLE
Fix typo

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -455,7 +455,7 @@ function! s:ApplyConfig(bufnr, config) abort
     endif
 
     " Set tabstop.  Skip this for terminal buffers, e.g., :FZF (#224).
-    if s:IsRuleActive('tab_width', a:config) && bufname(l:bufnr) !~# '^!\w*sh$'
+    if s:IsRuleActive('tab_width', a:config) && bufname(a:bufnr) !~# '^!\w*sh$'
         let l:tabstop = str2nr(a:config["tab_width"])
         call setbufvar(a:bufnr, '&tabstop', l:tabstop)
     else


### PR DESCRIPTION
This fixes https://github.com/editorconfig/editorconfig-vim/issues/224#issuecomment-1829630143.