### PR TITLE
Fix typo (from Vim downstream)

### DIFF
--- a/autoload/editorconfig_core/ini.vim
+++ b/autoload/editorconfig_core/ini.vim
@@ -1,6 +1,6 @@
 " autoload/editorconfig_core/ini.vim: Config-file parser for
 " editorconfig-core-vimscript and editorconfig-vim.
-" Modifed from the Python core's ini.py.
+" Modified from the Python core's ini.py.
 
 " Copyright (c) 2012-2019 EditorConfig Team {{{2
 " All rights reserved.


### PR DESCRIPTION
Change copied from downstream Vim commit dbf749b (runtime: Fix more
typos (#13354), 2023-10-16).

Co-authored-by: Viktor Szépe <viktor@szepe.net>