### PR TITLE
Add "Bundled versions" section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 This is an [EditorConfig][] plugin for Vim. This plugin can be found on both
 [GitHub][] and [Vim online][].
 
+## Bundled versions
+
+Depending on which version of Vim or Neovim you are using, you might not need to
+install this plugin at all:
+
+* Vim 9.0.1799 and above comes bundled with [a version of this plugin][].
+* Neovim 0.9 and above comes with [its own Lua-based implementation][].
+
+Both support the usual [properties][], including `max_line_length`.
+
 ## Installation
 
 To install this plugin, you can use one of the following ways:
@@ -138,6 +148,8 @@ Feel free to submit bugs, feature requests, and other issues to the
 [PreserveNoEOL]: http://www.vim.org/scripts/script.php?script_id=4550
 [Tim Pope's fugitive]: https://github.com/tpope/vim-fugitive
 [Vim online]: http://www.vim.org/scripts/script.php?script_id=3934
+[a version of this plugin]: https://github.com/vim/vim/pull/12902
+[its own Lua-based implementation]: https://github.com/neovim/neovim/commit/ab9a2c49253413dbbb31756a3eeddb354a663035
 [Vundle]: https://github.com/gmarik/Vundle.vim
 [archive]: https://github.com/editorconfig/editorconfig-vim/archive/master.zip
 [contribution guidelines]: https://github.com/editorconfig/editorconfig/blob/master/CONTRIBUTING.md#submitting-an-issue


### PR DESCRIPTION
Based on my research in <https://github.com/editorconfig/editorconfig-vim/issues/234#issuecomment-1949928227>. This allows people to understand at a glance whether they need to install the plugin at all.