### PR TITLE
Correct language name to "Vim script"

### DIFF
--- a/autoload/editorconfig.vim
+++ b/autoload/editorconfig.vim
@@ -1,4 +1,4 @@
-" autoload/editorconfig.vim: EditorConfig native Vimscript plugin
+" autoload/editorconfig.vim: EditorConfig native Vim script plugin
 " Copyright (c) 2011-2019 EditorConfig Team
 " All rights reserved.
 "

--- a/doc/editorconfig.txt
+++ b/doc/editorconfig.txt
@@ -47,7 +47,7 @@ Specify the mode of EditorConfig core. Generally it is OK to leave this option
 empty. Currently, the supported modes are "vim_core" (default) and
 "external_command".
 
-    vim_core:           Use the included VimScript EditorConfig Core.
+    vim_core:           Use the included Vim script EditorConfig Core.
     external_command:   Run external EditorConfig Core.
 
 If "g:EditorConfig_core_mode" is not specified, this plugin will automatically

--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -1,4 +1,4 @@
-" plugin/editorconfig.vim: EditorConfig native Vimscript plugin file
+" plugin/editorconfig.vim: EditorConfig native Vim script plugin file
 " Copyright (c) 2011-2019 EditorConfig Team
 " All rights reserved.
 "

--- a/tests/core/ecvimlib.ps1
+++ b/tests/core/ecvimlib.ps1
@@ -1,4 +1,4 @@
-# ecvimlib.ps1: Editorconfig Vimscript core CLI, PowerShell version,
+# ecvimlib.ps1: Editorconfig Vim script core CLI, PowerShell version,
 # library routines.
 # Copyright (c) 2018--2019 Chris White.  All rights reserved.
 # Licensed CC-BY-SA, version 3.0 or any later version, at your option.

--- a/tests/core/editorconfig
+++ b/tests/core/editorconfig
@@ -1,11 +1,11 @@
 #!/bin/bash
-# editorconfig: Editorconfig Vimscript core CLI
+# editorconfig: Editorconfig Vim script core CLI
 # Copyright (c) 2018--2019 Chris White.  All rights reserved.
 # Licensed CC-BY-SA, version 3.0 or any later version, at your option.
 
 # Documentation {{{1
 helpstr=$(cat<<'EOF'
-editorconfig: command-line invoker for the Vimscript editorconfig core
+editorconfig: command-line invoker for the Vim script editorconfig core
 
 Normal usage:
     editorconfig [-f <config-file name>] [-b <version>]
@@ -117,7 +117,7 @@ done
 shift $(( $OPTIND - 1 ))
 
 if [[ $print_ver ]]; then
-    echo "EditorConfig VimScript Core Version 0.12.2"
+    echo "EditorConfig Vim script Core Version 0.12.2"
     exit 0
 fi
 

--- a/tests/core/editorconfig2.ps1
+++ b/tests/core/editorconfig2.ps1
@@ -1,4 +1,4 @@
-# editorconfig2.ps1: Editorconfig Vimscript core CLI, PowerShell version
+# editorconfig2.ps1: Editorconfig Vim script core CLI, PowerShell version
 # Copyright (c) 2018--2019 Chris White.  All rights reserved.
 # Licensed CC-BY-SA, version 3.0 or any later version, at your option.
 # Thanks to https://cecs.wright.edu/~pmateti/Courses/233/Labs/Scripting/bashVsPowerShellTable.html
@@ -90,7 +90,7 @@ if($debug) {
 }
 
 if($report_version) {
-    echo "EditorConfig VimScript Core Version 0.12.2"
+    echo "EditorConfig Vim script Core Version 0.12.2"
     exit
 }
 

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -35,7 +35,7 @@ if [[ "$TEST_WHICH" = 'plugin' ]]; then       # test plugin
         bundle install --jobs=3 --retry=3 --deployment
     fi
 
-    # Use the standalone Vimscript EditorConfig core to test the plugin's
+    # Use the standalone Vim script EditorConfig core to test the plugin's
     # external_command mode
     export EDITORCONFIG_VIM_EXTERNAL_CORE=tests/core/editorconfig
 


### PR DESCRIPTION
Fix correct name to "Vim script"
https://github.com/vim/vim/pull/15863

runtime(misc): Use consistent "Vim script" spelling
https://github.com/vim/vim/commit/a4205471adae39c80fb7f151a4f33051fcb80001

--
Best regards,
Hirohito Higashi (h_east)