### PR TITLE
fix: E495 on VimEnter with 'verbose'

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -209,15 +209,9 @@ function! s:UseConfigFiles(from_autocmd) abort " Apply config to the current buf
     " from_autocmd is truthy if called from an autocmd, falsy otherwise.
 
     " Get the properties of the buffer we are working on
-    if a:from_autocmd
-        let l:bufnr = str2nr(expand('<abuf>'))
-        let l:buffer_name = expand('<afile>:p')
-        let l:buffer_path = expand('<afile>:p:h')
-    else
-        let l:bufnr = bufnr('%')
-        let l:buffer_name = expand('%:p')
-        let l:buffer_path = expand('%:p:h')
-    endif
+    let l:bufnr = a:from_autocmd ? str2nr(expand('<abuf>')) : bufnr('%')
+    let l:buffer_name = expand('#'.l:bufnr.':p')
+    let l:buffer_path = expand('#'.l:bufnr.':p:h')
     call setbufvar(l:bufnr, 'editorconfig_tried', 1)
 
     " Only process normal buffers (do not treat help files as '.txt' files)


### PR DESCRIPTION
Problem:
If 'verbose' is non-zero, VimEnter autocmd when starting vim without args raises E495:

    Error detected while processing VimEnter Autocommands for "*"..function <SNR>37_UseConfigFiles:
    line    6:
    E495: No autocommand file name to substitute for "<afile>"

Solution:
Replace `<afile>` with `#n` (:help :_#n).