### PR TITLE
Set commentstring

### DIFF
--- a/ftdetect/editorconfig.vim
+++ b/ftdetect/editorconfig.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead .editorconfig setfiletype dosini
+autocmd BufNewFile,BufRead .editorconfig setlocal commentstring=#\ %s


### PR DESCRIPTION
In recent versions of Vim and Neovim (`filetype=editorconfig`) `commentstring` seems empty. In an older version of Vim (`filetype=dosini`), it's set to `; %s`.

According to the file format page [0], both semicolons (;) and octothorpes (#) can be used for comments. However, octothorpes seem to be the most commonly used [1].

I'm not entirely sure if this is the best place to set `commentstring`.

[0]: https://docs.editorconfig.org/en/master/editorconfig-format.html
[1]: https://editorconfig.org/#example-file