### PR TITLE
Delete ftdetect files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The core included the code to parse `.editorconfig` files.
 This plugin **includes** the core, so you don't need to download the
 core separately.
 
+### Version Supported
+
+Vim v9.1.0543 and Neovim v0.10.x or earlier versions: This plugin after version
+1.2.1 will not automatically set `.editorconfig` filetype to `dosini`. Please
+install version 1.2.1 of this plugin if you would like to retain this behavior.
+
 ## Supported properties
 
 The EditorConfig Vim plugin supports the following EditorConfig [properties][]:

--- a/ftdetect/editorconfig.vim
+++ b/ftdetect/editorconfig.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead .editorconfig setfiletype dosini


### PR DESCRIPTION
As discussed in
https://github.com/editorconfig/editorconfig-vim/pull/243#issuecomment-2584458108, Vim and Neovim already support detecting editorconfig files. Our ftdetect still leads Vim to use dosini file type, which is not fully optimized for .editorconfig.