### PR TITLE
Fix stray characters on file open with external editorconfig

### DIFF
--- a/plugin/editorconfig.vim
+++ b/plugin/editorconfig.vim
@@ -355,7 +355,7 @@ function! s:SpawnExternalParser(bufnr, cmd, target) " {{{2
     let l:cmd = l:cmd . ' ' . shellescape(a:target)
     call s:ResetShellSlash(a:bufnr)
 
-    let l:parsing_result = split(system(l:cmd), '\v[\r\n]+')
+    silent let l:parsing_result = split(system(l:cmd), '\v[\r\n]+')
 
     " if editorconfig core's exit code is not zero, give out an error
     " message


### PR DESCRIPTION
External editorconfig core is much faster in my case but sometimes I got stray characters at the first line, see example:
<img width="1320" height="1040" alt="stray-example" src="https://github.com/user-attachments/assets/c3263466-9c66-4c4f-a05e-8d0c4675c59b" />

Looks like system call to external editorconfig should be wrapped with silent.
